### PR TITLE
Display an error message for impossible values of minZoom and maxZoom

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -44,7 +44,7 @@ class Transform {
         this._minZoom = zoom;
         this.zoom = Math.max(this.zoom, zoom);
         if (this._maxZoom != null && this._minZoom > this._maxZoom)
-            throw new Error("maxZoom must always be greater than minZoom");
+            return this.fire('error', new Error('maxZoom must always be greater than minZoom'));
     }
 
     get maxZoom() { return this._maxZoom; }
@@ -53,7 +53,7 @@ class Transform {
         this._maxZoom = zoom;
         this.zoom = Math.min(this.zoom, zoom);
         if (this._minZoom != null && this._minZoom > this._maxZoom)
-            throw new Error("maxZoom must always be greater than minZoom");
+            return this.fire('error', new Error('maxZoom must always be greater than minZoom'));
     }
 
     get worldSize() {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -23,8 +23,8 @@ class Transform {
         this.tileSize = 512; // constant
 
         this._renderWorldCopies = renderWorldCopies === undefined ? true : renderWorldCopies;
-        this._minZoom = minZoom || 0;
-        this._maxZoom = maxZoom || 22;
+        this.minZoom = minZoom || 0;
+        this.maxZoom = maxZoom || 22;
 
         this.latRange = [-85.05113, 85.05113];
 
@@ -43,6 +43,8 @@ class Transform {
         if (this._minZoom === zoom) return;
         this._minZoom = zoom;
         this.zoom = Math.max(this.zoom, zoom);
+        if (this._maxZoom != null && this._minZoom > this._maxZoom)
+            throw new Error("minZoom must be smaller than maxZoom.");
     }
 
     get maxZoom() { return this._maxZoom; }
@@ -50,6 +52,8 @@ class Transform {
         if (this._maxZoom === zoom) return;
         this._maxZoom = zoom;
         this.zoom = Math.min(this.zoom, zoom);
+        if (this._minZoom != null && this._minZoom > this._maxZoom)
+            throw new Error("maxZoom must be greater than minZoom.");
     }
 
     get worldSize() {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -44,7 +44,7 @@ class Transform {
         this._minZoom = zoom;
         this.zoom = Math.max(this.zoom, zoom);
         if (this._maxZoom != null && this._minZoom > this._maxZoom)
-            throw new Error("minZoom must be smaller than maxZoom.");
+            throw new Error("maxZoom must always be greater than minZoom");
     }
 
     get maxZoom() { return this._maxZoom; }
@@ -53,7 +53,7 @@ class Transform {
         this._maxZoom = zoom;
         this.zoom = Math.min(this.zoom, zoom);
         if (this._minZoom != null && this._minZoom > this._maxZoom)
-            throw new Error("maxZoom must be greater than minZoom.");
+            throw new Error("maxZoom must always be greater than minZoom");
     }
 
     get worldSize() {

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -194,6 +194,13 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('throws on maxZoom smaller than minZoom', (t) => {
+        t.throws(() => {
+            new Transform(20, 10);
+        }, Error, 'maxZoom must always be greater than minZoom');
+        t.end();
+    });
+
     t.test('clamps pitch', (t) => {
         const transform = new Transform();
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -194,9 +194,27 @@ test('transform', (t) => {
         t.end();
     });
 
-    t.test('throws on maxZoom smaller than minZoom', (t) => {
+    t.test('fire on maxZoom smaller than minZoom at init', (t) => {
         t.throws(() => {
             new Transform(20, 10);
+        }, Error, 'maxZoom must always be greater than minZoom');
+        t.end();
+    });
+
+    t.test('fire on maxZoom smaller than minZoom at set maxZoom', (t) => {
+        t.throws(() => {
+            const transform = new Transform(10, 15);
+
+            transform.maxZoom = 5;
+        }, Error, 'maxZoom must always be greater than minZoom');
+        t.end();
+    });
+
+    t.test('fire on maxZoom smaller than minZoom at set minZoom', (t) => {
+        t.throws(() => {
+            const transform = new Transform(10, 15);
+
+            transform.minZoom = 20;
         }, Error, 'maxZoom must always be greater than minZoom');
         t.end();
     });


### PR DESCRIPTION
Fixes #2264

When creating a map where holds that `minZoom > maxZoom` the map is loaded and the user cannot zoom. The changes in this pull request throw an error when the above case holds. See the following example: https://jsfiddle.net/7d365j4s/

## Launch Checklist

The pull request needs to be reviewed by at least two other team members. When the pull request has been reviewed we can close this pull request and create a new pull request to the **mapbox/mapbox-gl-js** repository.